### PR TITLE
modify snap name to allow publishing to brand store

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,13 +1,13 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: aws-iot-greengrass-v2
+name: grainger-aws-iot-greengrass-v2
 base: core20
 version: '2.4.0'
 summary: AWS supported software that extends cloud capabilities to local devices.
 description: |
   AWS supported software that extends cloud capabilities to local devices.
-grade: devel # must be 'stable' to release into candidate/stable channels
+grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict
 
 


### PR DESCRIPTION
*Description of changes:*

We have a CI pipeline that is building the snap for our Brand store. In order to be able to publish to the `candidate` and `stable` channels, we need `grade: stable` to be set.

Additionally, we need the name to be changed so we can publish to our brand store.

Currently we are doing this by modifying the `snapcraft.yaml` file at build time programmatically, but it may make more sense to change it here permanently, if there's an appetite for that. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
