### PR TITLE
updates to fix java cert issues when installing from snap store

### DIFF
--- a/amd64/local-scripts/iot-greengrass-setup.py
+++ b/amd64/local-scripts/iot-greengrass-setup.py
@@ -22,6 +22,10 @@ def get_aws_credentials():
 
     return access_key, secret_key, region
 
+def get_account_id():
+    sts_client = boto3.client('sts')
+    return sts_client.get_caller_identity()['Account']
+
 def get_device_info():
     """Get device information from user"""
     print("\n=== Device Configuration ===")
@@ -45,6 +49,7 @@ def create_aws_clients(access_key, secret_key, region):
         iot_client = session.client('iot')
         iam_client = session.client('iam')
         sts_client = session.client('sts')
+
         account_id = sts_client.get_caller_identity()['Account']
 
         return iot_client, iam_client, account_id
@@ -274,7 +279,7 @@ def install_greengrass_v2(thing_name, region, cert_path, private_key_path, root_
         "services": {
             "aws.greengrass.Nucleus": {
                 "componentType": "NUCLEUS",
-                "version": "2.12.0",
+                "version": "2.14.3",
                 "configuration": {
                     "awsRegion": region,
                     "iotRoleAlias": iot_role_alias,
@@ -354,6 +359,8 @@ def install_greengrass_v2(thing_name, region, cert_path, private_key_path, root_
         install_cmd = [
             java_path,
             "-Droot=" + greengrass_root,
+            "-Djavax.net.ssl.trustStore=$SNAP/etc/ssl/certs/java/cacerts",
+            "-Djavax.net.ssl.trustStoreType=JKS",
             "-Dlog.store=FILE",
             "-jar", installer_jar,
             "--init-config", config_path,

--- a/amd64/snap/snapcraft.yaml
+++ b/amd64/snap/snapcraft.yaml
@@ -10,6 +10,11 @@ grade: stable
 environment:
   PATH: $SNAP/docker/bin:$PATH
   PYTHONPATH: $SNAP/lib/python3.12/site-packages:$PYTHON_PATH
+  JAVA_HOME: $SNAP/usr/lib/jvm/java-11-openjdk-amd64
+
+layout:
+  /etc/ssl/certs/java:
+    bind: $SNAP/etc/ssl/certs/java
 
 plugs:
   docker-executables:
@@ -24,9 +29,7 @@ slots:
     content: shared-files
     source:
       read:
-        - $SNAP_COMMON/shared
-      write:
-        - $SNAP_COMMON/shared
+        - $SNAP_COMMON/shared/ml
 
 apps:
   configure:
@@ -92,5 +95,13 @@ parts:
 
       cp local-scripts/greengrass-wrapper.sh $CRAFT_PART_INSTALL/bin/
       chmod +x $CRAFT_PART_INSTALL/bin/greengrass-wrapper.sh
+
+      mkdir -p $CRAFT_PART_INSTALL/etc/ssl/certs/java
+      mkdir -p $CRAFT_PART_INSTALL/usr/lib/jvm/java-11-openjdk-amd64/lib/security
+      touch $CRAFT_PART_INSTALL/etc/ssl/certs/blacklisted.certs
+
+      rm -f $CRAFT_PART_INSTALL/usr/lib/jvm/java-11-openjdk-amd64/lib/security/blacklisted.certs
+      touch $CRAFT_PART_INSTALL/usr/lib/jvm/java-11-openjdk-amd64/lib/security/blacklisted.certs
+
     organize:
       shared/: shared/

--- a/arm64/local-scripts/iot-greengrass-setup.py
+++ b/arm64/local-scripts/iot-greengrass-setup.py
@@ -274,7 +274,7 @@ def install_greengrass_v2(thing_name, region, cert_path, private_key_path, root_
         "services": {
             "aws.greengrass.Nucleus": {
                 "componentType": "NUCLEUS",
-                "version": "2.12.0",
+                "version": "2.14.3",
                 "configuration": {
                     "awsRegion": region,
                     "iotRoleAlias": iot_role_alias,
@@ -354,6 +354,8 @@ def install_greengrass_v2(thing_name, region, cert_path, private_key_path, root_
         install_cmd = [
             java_path,
             "-Droot=" + greengrass_root,
+            "-Djavax.net.ssl.trustStore=$SNAP/etc/ssl/certs/java/cacerts",
+            "-Djavax.net.ssl.trustStoreType=JKS",
             "-Dlog.store=FILE",
             "-jar", installer_jar,
             "--init-config", config_path,

--- a/arm64/snap/snapcraft.yaml
+++ b/arm64/snap/snapcraft.yaml
@@ -10,6 +10,11 @@ grade: stable
 environment:
   PATH: $SNAP/docker/bin:$PATH
   PYTHONPATH: $SNAP/lib/python3.12/site-packages:$PYTHON_PATH
+  JAVA_HOME: $SNAP/usr/lib/jvm/java-11-openjdk-arm64
+
+layout:
+  /etc/ssl/certs/java:
+    bind: $SNAP/etc/ssl/certs/java
 
 plugs:
   docker-executables:
@@ -18,10 +23,18 @@ plugs:
     target: $SNAP/docker
     default-provider: docker
 
+slots:
+  shared-files:
+    interface: content
+    content: shared-files
+    source:
+      read:
+        - $SNAP/shared
+
 apps:
   configure:
     command: bin/python3 $SNAP/bin/iot-greengrass-setup.py
-    plugs:
+    plugs: 
       - network
       - network-bind
       - home
@@ -32,6 +45,8 @@ apps:
       - docker-executables
       - docker
       - camera
+    slots:
+      - shared-files
 
   greengrass-daemon:
     command: bin/greengrass-wrapper.sh
@@ -49,6 +64,8 @@ apps:
       - docker-executables
       - docker
       - camera
+    slots:
+      - shared-files
 
 parts:
   iot-greengrass-app:
@@ -57,16 +74,11 @@ parts:
     python-requirements:
       - requirements.txt
     stage-packages:
+      - ca-certificates
+      - ca-certificates-java
       - openjdk-11-jre-headless
     build-packages:
       - wget
-    override-stage: |
-      craftctl default
-      # Fix Java security symlinks by creating empty files
-      rm -f $CRAFT_STAGE/usr/lib/jvm/java-11-openjdk-arm64/lib/security/blacklisted.certs
-      rm -f $CRAFT_STAGE/usr/lib/jvm/java-11-openjdk-arm64/lib/security/cacerts
-      touch $CRAFT_STAGE/usr/lib/jvm/java-11-openjdk-arm64/lib/security/blacklisted.certs
-      touch $CRAFT_STAGE/usr/lib/jvm/java-11-openjdk-arm64/lib/security/cacerts
     override-build: |
       # Run default Python plugin build first
       craftctl default
@@ -83,3 +95,12 @@ parts:
 
       cp local-scripts/greengrass-wrapper.sh $CRAFT_PART_INSTALL/bin/
       chmod +x $CRAFT_PART_INSTALL/bin/greengrass-wrapper.sh
+
+      mkdir -p $CRAFT_PART_INSTALL/etc/ssl/certs/java
+      mkdir -p $CRAFT_PART_INSTALL/usr/lib/jvm/java-11-openjdk-amd64/lib/security
+      touch $CRAFT_PART_INSTALL/etc/ssl/certs/blacklisted.certs
+
+      rm -f $CRAFT_PART_INSTALL/usr/lib/jvm/java-11-openjdk-amd64/lib/security/blacklisted.certs
+      touch $CRAFT_PART_INSTALL/usr/lib/jvm/java-11-openjdk-amd64/lib/security/blacklisted.certs
+    organize:
+      shared/: shared/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Modifications to snapcraft.yaml and the configuration script for both amd64 and arm64 versions of the snap to fix issues relating to java certificates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
